### PR TITLE
Add a print method to the ProjectReporter class

### DIFF
--- a/R/reporter-project.R
+++ b/R/reporter-project.R
@@ -62,7 +62,7 @@ ProjectReporter <- R6::R6Class("ProjectReporter", inherit = testthat::ListReport
       end_report <- self$end_reporter()
       summary <- end_report$summary
       tests <- end_report$tests
-      cat("Tests:", summary$tests, ", Failures:", summary$failures, ", Errors: ", summary$errors, sep = "")
+      cat((summary$tests - summary$failures - summary$errors), "/", summary$tests, " tests passed",sep = "")
       cat("\n")
       for(i in seq_along(tests)) {
         test <- tests[[i]]

--- a/R/reporter-project.R
+++ b/R/reporter-project.R
@@ -61,8 +61,6 @@ ProjectReporter <- R6::R6Class("ProjectReporter", inherit = testthat::ListReport
     print = function() {
       end_report <- self$end_reporter()
       summary <- end_report$summary
-      tests <- do.call(rbind, lapply(end_report$tests, data.frame, stringsAsFactors=FALSE))
-      tests <- tests[ ! tests$success,  ]
       tests <- end_report$tests
       cat("Tests:", summary$tests, ", Failures:", summary$failures, ", Errors: ", summary$errors, sep = "")
       cat("\n")

--- a/R/reporter-project.R
+++ b/R/reporter-project.R
@@ -57,6 +57,23 @@ ProjectReporter <- R6::R6Class("ProjectReporter", inherit = testthat::ListReport
              message = message,
              success = success,
              outcome = outcome)
+    },
+    print = function() {
+      end_report <- self$end_reporter()
+      summary <- end_report$summary
+      tests <- do.call(rbind, lapply(end_report$tests, data.frame, stringsAsFactors=FALSE))
+      tests <- tests[ ! tests$success,  ]
+      tests <- end_report$tests
+      cat("Tests:", summary$tests, ", Failures:", summary$failures, ", Errors: ", summary$errors, sep = "")
+      cat("\n")
+      for(i in seq_along(tests)) {
+        test <- tests[[i]]
+        if(test$success) next
+        cat(">", test$outcome, "::", test$name)
+        cat("\n")
+        cat( test$message, "\n---\n")
+      }
+      invisible(self)
     }
   ),
   private = list(


### PR DESCRIPTION
Currently it's hard to author tests because it's hart to tell from the Rkernel.testthat output in the notebook wether a test failed or not. This fix adds a print method that produces somewhat useful printouts:


![image](https://user-images.githubusercontent.com/1006144/32690430-db53f1c4-c6f6-11e7-8c6a-bd9b93a2bb9e.png)
