### PR TITLE
[LE-591] Update to use previous version of testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: IRkernel.testthat
 Title: What the Package Does (one line, title case)
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: person("Michael", "Chow", email = "michael@datacamp.com", role = c("aut", "cre"))
 Description: Implements reporter for communicating testthat results to a jupyter client.
 License: All Rights Reserved

--- a/R/reporter-project.R
+++ b/R/reporter-project.R
@@ -46,7 +46,7 @@ ProjectReporter <- R6::R6Class("ProjectReporter", inherit = testthat::ListReport
             lapply(test$results, `[[`, 'message'),
             collapse = '\n')
 
-        res <- testthat:::sumarize_one_test_results(test)
+        res <- testthat:::summarize_one_test_results(test)
         success <- !any(res$failed, res$error)
         # figure out outcome, e.g. for counting errors later
         if (!success) {


### PR DESCRIPTION
**I haven't tested this**. It looks like testthat corrected the spelling on an internal function we use.

https://github.com/r-lib/testthat/blob/9711653d573eb0d068d85edd65568a37f0b631db/R/reporter-list.R#L105